### PR TITLE
Branch .env config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
-DB_PASSWORD= LTalleres98!P
+DB_PASSWORD= yourPostgresqlPassword
 DB_NAME=pawforpaw
 CLOUD_NAME=dziccimdv
 CLOUD_API_SECRET=EqMqNeqsh93xR1DtlA6OXXnvC6U


### PR DESCRIPTION
Con Juan habíamos renombrado el .env.development a .env.example. Pero

⚠️ .env.example no es cargado automáticamente por NestJS ni por @nestjs/config

Nest por defecto solo carga .env, .env.development, .env.production, etc.
Pero .env.example es solo un archivo de referencia, no para uso activo. Así que ahora, renombré el archivo y el proyecot funciona